### PR TITLE
Add some CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go:
+  - 1.7
+before_install: ./scripts/hack/symlink-gopath-travisci
+script:
+  - cd $HOME/gopath/src/github.com/awslabs/ecs-task-kite
+  - make build-deps
+  - make static-go-binary
+  - make test
+  - make lint
+

--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,4 @@ lint:
 	curl -s https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt > ./misc/ca-bundle.crt
 
 build-deps:
-	go get github.com/tools/godep
+	go get github.com/golang/lint/golint

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean:
 
 lint:
 	go vet ./...
-	for pkg in $(shell go list -f "{{.Dir}}" ./... | grep -v "/mocks/"); do golint $$pkg; done
+	for pkg in $(shell go list -f "{{.Dir}}" ./... | grep -v "/mocks"); do golint $$pkg; done
 
 ./misc/ca-bundle.crt:
 	@mkdir -p misc

--- a/lib/ecsclient/client.go
+++ b/lib/ecsclient/client.go
@@ -198,7 +198,7 @@ func New(cluster string, region string, ecsclient ecsiface.ECSAPI, ec2client ec2
 		var err error
 		region, err = ec2MetadataClient.Region()
 		if err != nil {
-			log.Errorf("Could not get region from EC2 metadata or environment", err)
+			log.Errorf("Could not get region from EC2 metadata or environment: %v", err)
 		}
 	}
 	if region == "" {

--- a/scripts/hack/symlink-gopath-travisci
+++ b/scripts/hack/symlink-gopath-travisci
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# This script is meant to make this package available in the canonical location
+# when running on Travis CI. This is useful for anyone who wishes to run Travis
+# CI against their fork of the repo.
+if [[ ! -d "$HOME/gopath/src/github.com/awslabs/ecs-task-kite" ]]; then
+	mkdir -p "$HOME/gopath/src/github.com/awslabs"
+	ln -s "$(pwd)" "$HOME/gopath/src/github.com/awslabs/ecs-task-kite"
+fi


### PR DESCRIPTION
Someone asked if this sucker still built, which made me wonder the same.

Wonder no more, with this container-scale CI we can be sure that this pile-o-code at the least can spit out a binary!

Passing build over [here](https://travis-ci.org/euank/ecs-task-kite/builds/172847282), you'll want to click the activate button over [here](https://travis-ci.org/awslabs/ecs-task-kite) before merging this .